### PR TITLE
Exclude .git directory from rsync

### DIFF
--- a/test/travis_package_make.bash
+++ b/test/travis_package_make.bash
@@ -1,6 +1,6 @@
 #!/bin/bash -xve
 
 #sync and make
-rsync -av ./ ~/catkin_ws/src/raspimouse_ros_2/
+rsync -av --exclude='.git/' ./ ~/catkin_ws/src/raspimouse_ros_2/
 cd ~/catkin_ws
 catkin_make


### PR DESCRIPTION
rsyncするときに、.gitディレクトリもコピーされているのですが、除いた方がコピー処理が減るので良いかなと思いました。