### PR TITLE
Fix typo. left value => right value

### DIFF
--- a/test/travis_test_motors.py
+++ b/test/travis_test_motors.py
@@ -35,7 +35,7 @@ class MotorTest(unittest.TestCase):
             time.sleep(0.1)
 
         self.file_check("rtmotor_raw_l0",m.left_hz,"wrong left value from motor_raw")
-        self.file_check("rtmotor_raw_r0",m.right_hz,"wrong left value from motor_raw")
+        self.file_check("rtmotor_raw_r0",m.right_hz,"wrong right value from motor_raw")
 
     def test_put_cmd_vel(self):
         pub = rospy.Publisher('/cmd_vel', Twist)

--- a/test/travis_test_motors1.py
+++ b/test/travis_test_motors1.py
@@ -25,7 +25,7 @@ class MotorTest(unittest.TestCase):
             time.sleep(0.1)
 
         self.file_check("rtmotor_raw_l0",m.left_hz,"wrong left value from motor_raw")
-        self.file_check("rtmotor_raw_r0",m.right_hz,"wrong left value from motor_raw")
+        self.file_check("rtmotor_raw_r0",m.right_hz,"wrong right value from motor_raw")
 
     def test_put_cmd_vel(self):
         pub = rospy.Publisher('/cmd_vel', Twist)

--- a/test/travis_test_motors2.py
+++ b/test/travis_test_motors2.py
@@ -32,7 +32,7 @@ class MotorTest(unittest.TestCase):
             time.sleep(0.1)
 
         self.file_check("rtmotor_raw_l0",m.left_hz,"wrong left value from motor_raw")
-        self.file_check("rtmotor_raw_r0",m.right_hz,"wrong left value from motor_raw")
+        self.file_check("rtmotor_raw_r0",m.right_hz,"wrong right value from motor_raw")
 
     def test_put_cmd_vel(self):
         pub = rospy.Publisher('/cmd_vel', Twist)


### PR DESCRIPTION
rtmotor_raw_r0の値をチェックしているところのassertionに失敗したときのメッセージに誤植があったので修正しました。