### PR TITLE
Set freqs(0,0) only one time since timeout to enable the buzzer function.

### DIFF
--- a/src/motors.cpp
+++ b/src/motors.cpp
@@ -222,8 +222,10 @@ int main(int argc, char **argv)
 
 	Rate loop_rate(10);
 	while(ok()){
-		if(in_cmdvel and Time::now().toSec() - last_cmdvel.toSec() >= 1.0)
+		if(in_cmdvel and Time::now().toSec() - last_cmdvel.toSec() >= 1.0){
 			setFreqs(0,0);
+			in_cmdvel = false;
+		}
 
 		pub_odom.publish(send_odom());
 		spinOnce();


### PR DESCRIPTION
Raspberry Pi Mouse can not control its motors and buzzer at same time.

So this PR fix a motor function to enable controlling the buzzer after stopping the motors.