### PR TITLE
Call catkin_install_python() in CMakeLists.txt to support Python2 and Python3.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,9 @@ target_link_libraries(lightsensors ${catkin_LIBRARIES})
 #   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 # )
 
+catkin_install_python(PROGRAMS scripts/buzzer.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+
 #############
 ## Testing ##
 #############


### PR DESCRIPTION
This PR changes `CMakeLists.txt` to support Python3.
Python3 is default Python version in ROS Noetic (Ubuntu 20.04).

The function `catkin_install_python()` installs python scripts with rewriting a Shebang to specific versions 
(ex. `#!/usr/bin/env python` -> `#!/usr/bin/python3`).

This also works in Python2 environments (ex. ROS Melodic).

Ref: http://wiki.ros.org/UsingPython3/SourceCodeChanges#Changing_shebangs